### PR TITLE
Accept HEC configuration as env variables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,11 +8,5 @@ snmp:
     v1:
       - public
       - "my-area"
-hec:
-  protocol: https
-  host: 127.0.0.1
-  port: 8088
-  endpoint: /services/collector/event
-  authentication_token: 6b5dcda2-6ead-46bf-a03e-6a9f24c8bd30
 thread-pool:
   max-suggested-working-threads: 10

--- a/splunk_connect_for_snmp_traps/manager/hec_config.py
+++ b/splunk_connect_for_snmp_traps/manager/hec_config.py
@@ -1,15 +1,33 @@
-class HecConfiguration:
-    def __init__(self, hec_config):
-        self._protocol = hec_config['protocol']
-        self._host = hec_config['host']
-        self._port = hec_config['port']
-        self._endpoint = hec_config['endpoint']
-        self._authentication_token = hec_config['authentication_token']
+import os
 
-    def endpoint(self):
-        from urllib.parse import urlunsplit
-        base_url = f'{self._host}:{self._port}'
-        return urlunsplit((self._protocol, base_url, self._endpoint, '', ''))
+
+class HecConfiguration:
+    endpoints_env_variable_name = 'SPLUNK_HEC_URL'
+    authentication_token_env_variable_name = 'SPLUNK_HEC_TOKEN'
+    enable_ssl_env_variable_name = 'SPLUNK_HEC_TLS_VERIFY'
+
+    def __init__(self):
+        urls = os.environ.get(HecConfiguration.endpoints_env_variable_name)
+        if urls is None:
+            raise ValueError(f'{HecConfiguration.endpoints_env_variable_name} environment variable undefined')
+        self._urls_list = urls.split()
+
+        authentication_token = os.environ.get(HecConfiguration.authentication_token_env_variable_name)
+        if authentication_token is None:
+            raise ValueError(
+                f'{HecConfiguration.authentication_token_env_variable_name} environment variable undefined')
+        self._authentication_token = authentication_token
+
+        enable_ssl = os.environ.get(HecConfiguration.enable_ssl_env_variable_name)
+        if enable_ssl is None:
+            raise ValueError(f'{HecConfiguration.enable_ssl_env_variable_name} environment variable undefined')
+        self._enable_ssl = True if enable_ssl.lower() == 'yes' else False
+
+    def get_endpoints(self):
+        return self._urls_list
 
     def get_authentication_token(self):
         return self._authentication_token
+
+    def is_ssl_enabled(self):
+        return self._enable_ssl

--- a/tests/test_hec_config.py
+++ b/tests/test_hec_config.py
@@ -1,0 +1,59 @@
+import os
+from unittest import TestCase
+
+from splunk_connect_for_snmp_traps.manager.hec_config import HecConfiguration
+
+
+class TestHecConfiguration(TestCase):
+    def setUp(self):
+        env_vars = (HecConfiguration.endpoints_env_variable_name,
+                    HecConfiguration.authentication_token_env_variable_name,
+                    HecConfiguration.enable_ssl_env_variable_name)
+        for env_var in env_vars:
+            if os.environ.get(env_var) is not None:
+                del os.environ[env_var]
+
+    def test_no_env_variable_defined_for_hec(self):
+        self.assertRaises(ValueError, HecConfiguration)
+
+    def test_only_hec_endpoints_defined(self):
+        os.environ[HecConfiguration.endpoints_env_variable_name] = 'http://127.0.0.1:8088/services/hec'
+        self.assertRaises(ValueError, HecConfiguration)
+
+    def test_hec_endpoints_and_token_defined(self):
+        os.environ[HecConfiguration.endpoints_env_variable_name] = 'http://127.0.0.1:8088/services/hec'
+        os.environ[HecConfiguration.authentication_token_env_variable_name] = '12345678'
+        self.assertRaises(ValueError, HecConfiguration)
+
+    def test_all_environment_variables_defined_multiple_urls(self):
+        os.environ[
+            HecConfiguration.endpoints_env_variable_name] = 'http://127.0.0.1:8088/services/hec1   ' \
+                                                            'http://127.0.0.1:8088/services/hec2 '
+        os.environ[HecConfiguration.authentication_token_env_variable_name] = '12345678'
+        os.environ[HecConfiguration.enable_ssl_env_variable_name] = 'Yes'
+
+        config = HecConfiguration()
+        self.assertEqual(config.get_endpoints(),
+                         ['http://127.0.0.1:8088/services/hec1', 'http://127.0.0.1:8088/services/hec2'])
+        self.assertEqual(config.get_authentication_token(), '12345678')
+        self.assertTrue(config.is_ssl_enabled())
+
+    def test_all_environment_variables_defined_ssl_enabled(self):
+        os.environ[HecConfiguration.endpoints_env_variable_name] = 'http://127.0.0.1:8088/services/hec'
+        os.environ[HecConfiguration.authentication_token_env_variable_name] = '12345678'
+        os.environ[HecConfiguration.enable_ssl_env_variable_name] = 'Yes'
+
+        config = HecConfiguration()
+        self.assertEqual(config.get_endpoints(), ['http://127.0.0.1:8088/services/hec'])
+        self.assertEqual(config.get_authentication_token(), '12345678')
+        self.assertTrue(config.is_ssl_enabled())
+
+    def test_all_environment_variables_defined_ssl_disabled(self):
+        os.environ[HecConfiguration.endpoints_env_variable_name] = 'http://127.0.0.1:8088/services/hec'
+        os.environ[HecConfiguration.authentication_token_env_variable_name] = '12345678'
+        os.environ[HecConfiguration.enable_ssl_env_variable_name] = 'No'
+
+        config = HecConfiguration()
+        self.assertEqual(config.get_endpoints(), ['http://127.0.0.1:8088/services/hec'])
+        self.assertEqual(config.get_authentication_token(), '12345678')
+        self.assertFalse(config.is_ssl_enabled())


### PR DESCRIPTION
- Now we can configure HEC using the following environment variables:
-- SPLUNK_HEC_URL: a space-separated list of URLs
-- SPLUNK_HEC_TOKEN
-- SPLUNK_HEC_TLS_VERIFY: Yes/No. The comparison is case insensitive, so any "Yes" combination
   will work.